### PR TITLE
Update general section of par file for v22.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 source/doxygen/*
+build/

--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -17,6 +17,9 @@ Glossary
     API
       Application Programming Interface
 
+    AVM
+      Artificial Viscosity Method described in [Persson]_
+
     BDF
       Backward Differentiation Formula
 

--- a/source/references.rst
+++ b/source/references.rst
@@ -18,6 +18,9 @@ References
 .. [Launder] Launder, B.E. and Spalding, D.B. "The Numerical Computation of Turbulent Flows,"
     *Computer Methods in Applied Mechanics and Engineering* **3** 269-289 (1974)
 
+.. [Persson] Persson, P.-O. and Peraire, J. "Sub-Cell Shock Capturing for Discontinuous Galerkin Methods",
+   *44th AIAA Aerospace Sciences Meeting and Exhibit* (2006)
+
 .. [Russo] Russo, F. and Basse, N.T. "Scaling of Turbulence Intensity for Low-Speed FLow in Smooth Pipes,"
     *Flow Measurement and Instrumentation* **52** 101-114 (2016)
 


### PR DESCRIPTION
The parameter list of the `GENERAL` section has been updated for v22.0 based on the code in `src/io/parReader.cpp`. 

Also, the `CASEDATA` section has been added, the syntax of the new parameters with subsettings has been explained, there is a statement about parameter validation.

The "common" section has been added. A lot more needs to be added there (mainly solver settings). For now, it only contains the `regularization` settings since `filtering` (which was in `GENERAL`) is deprecated.
